### PR TITLE
【サーバサイド】商品詳細表示

### DIFF
--- a/app/assets/stylesheets/_show.scss
+++ b/app/assets/stylesheets/_show.scss
@@ -55,6 +55,48 @@
             }
           }
         }
+        // 編集・削除ボタン
+        &__login {
+          ul {
+            li {
+              background-color:#3CCACE;
+              text-align: center;
+              margin: 0 auto;
+              margin-bottom: 20px;
+              padding: 20px 0 20px 0;
+              width: 620px;
+              height: 60px;
+              a {
+                font-size: 30px;
+                color: #fff;
+                text-decoration: none;
+                font-weight: bold;
+                line-height: 20px;
+              }
+            }
+          }
+        }
+        // 購入ボタン
+        &__logout {
+          ul {
+            li {
+              background-color:#3CCACE;
+              text-align: center;
+              margin: 0 auto;
+              margin-bottom: 20px;
+              padding: 20px 0 20px 0;
+              width: 620px;
+              height: 60px;
+              a {
+                font-size: 30px;
+                color: #fff;
+                text-decoration: none;
+                font-weight: bold;
+                line-height: 20px;
+              }
+            }
+          }
+        }
         &__text {
           line-height: 1.5;
           font-size: 18px;

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,5 @@
 class ItemsController < ApplicationController
-  before_action :set_item, only: [:edit, :update, :destroy]
+  before_action :set_item, only: [:edit, :update, :destroy, :show]
   def index
     @items = Item.includes(:images).limit(9).order('created_at DESC')
   end
@@ -20,7 +20,10 @@ class ItemsController < ApplicationController
       render :new
     end
   end
-  
+
+  def show
+  end
+
   def get_category_children  
     @category_children = Category.find_by(name: "#{params[:parent_name]}", ancestry: nil).children  
   end

--- a/app/views/items/_item.html.haml
+++ b/app/views/items/_item.html.haml
@@ -1,7 +1,7 @@
 
 .main__pickup__product__lists
   .main__pickup__product__lists__list
-    = link_to "#", class: "main__pickup__product__lists__list__link" do
+    = link_to item_path(item.id), class: "main__pickup__product__lists__list__link" do
       = image_tag item.images[0].url.url, class: 'main__pickup__product__lists__list__link__img'
       .main__pickup__product__lists__list__link__body
         %h3.main__pickup__product__lists__list__link__body__name

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -8,46 +8,59 @@
     %li
       = icon('fa', 'angle-right')
     %li
-      = link_to "ベビー・キッズ", "#"
+      = link_to @item.category.root.name,"#"
     %li
       = icon('fa', 'angle-right')
     %li
-      = link_to "ベビー服(男女兼用)  ~95cm", "#"
+      = link_to @item.category.parent.name,"#"
     %li
       = icon('fa', 'angle-right')
     %li
-      = link_to "アウター", "#"
+      = link_to @item.category.name,"#"
     %li
       = icon('fa', 'angle-right')
     %li
       %p
-        product3
+        = @item.name
 
 .main
   .main__show
     .main__show__content
       .main__show__content__item-box
         %h2.main__show__content__item-box__name
-          product3
+          = @item.name
         .main__show__content__item-box__body
-          = image_tag asset_path('product-sample3.png')
+          = image_tag @item.images[0].url.url
           %ul
-            %li
-              = image_tag asset_path('product-sample3.png')
-            %li
-              = image_tag asset_path('product-sample2.png')
-            %li 
-              = image_tag asset_path('product-sample1.png')
+            - @item.images.each do |image|
+              %li
+                = image_tag image.url.url
+
         .main__show__content__item-box__price
           %span
-            ¥30000
+            ¥
+            = @item.price
           .main__show__content__item-box__price__detail
             %span
               (税込)
             %span
               送料込み
+        -# 編集・削除ボタン（ログイン時に出る）
+        - if user_signed_in? && current_user.id
+          .main__show__content__item-box__login
+            %ul
+              %li
+                = link_to '商品の編集', "/items/#{@item.id}/edit", method: :get
+              %li
+                = link_to '商品の削除', "/items/#{@item.id}", method: :delete
+        -# 削除ボタン（未ログイン時に出る）
+        - if not user_signed_in?
+          .main__show__content__item-box__logout
+            %ul
+              %li
+                = link_to '購入画面に進む'
         .main__show__content__item-box__text
-          親譲りの無鉄砲で小供の時から損ばかりしている。小学校に居る時分学校の二階から飛び降りて一週間ほど腰を抜かした事がある。なぜそんな無闇をしたと聞く人があるかも知れぬ。別段深い理由でもない。新築の二階から首を出していたら、同級生の一人が冗談に、いくら威張っても、そこから飛び降りる事は出来まい。弱虫やーい。と囃したからである。小使に負ぶさって帰って来た時、おやじが大きな眼をして二階ぐらいから飛び降りて腰
+          = @item.content
         .main__show__content__item-box__table
           %table
             %tbody
@@ -60,9 +73,9 @@
                 %th
                   カテゴリー
                 %td
-                  = link_to "ベビー・キッズ","#"
-                  = link_to "ベビー服(男女兼用)  ~95cm","#"
-                  = link_to "アウター","#"
+                  = link_to @item.category.root.name,"#"
+                  = link_to @item.category.parent.name,"#"
+                  = link_to @item.category.name,"#"
               %tr
                 %th
                   ブランド
@@ -75,22 +88,22 @@
                 %th
                   商品の状態
                 %td
-                  未使用に近い
+                  = @item.status
               %tr
                 %th
                   配送料の負担
                 %td
-                  送料込み（出品者負担）
+                  = @item.postage
               %tr
                 %th
                   発送元の地域
                 %td
-                  = link_to "岩手県","#"
+                  = link_to @item.prefecture.name
               %tr
                 %th
                   発送日の目安
                 %td
-                  4-7日で発送
+                  = @item.shipping_days
         .main__show__content__item-box__optional
           %ul.main__show__content__item-box__optional__lists
             %li.main__show__content__item-box__optional__lists__btn.favorite-btn#favorite-btn
@@ -123,6 +136,7 @@
     .main__show__related-items
       = link_to "#" do
         ベビー・キッズをもっと見る
+
 
 = render partial: 'app-banner'
 

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -129,7 +129,7 @@ ja:
       new:
         sign_in: ログイン
       signed_in: ログインしました。
-      signed_out: ログアウトしました。
+      signed_out: ''
     shared:
       links:
         back: 戻る

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,7 @@
 Rails.application.routes.draw do
 
+  root 'items#index'
+
   devise_for :users, controllers: {
     registrations: 'users/registrations',
     sessions: 'users/sessions'   
@@ -10,10 +12,9 @@ Rails.application.routes.draw do
     post 'delivery_info', to: 'users/registrations#create_delivery_info'
   end
 
-  root 'items#index'
 
   # 仮置き
-  resources :items, except: :show do
+  resources :items do
     collection do
       get 'get_category_children', defaults: { format: 'json' }
       get 'get_category_grandchildren', defaults: { format: 'json' }


### PR DESCRIPTION
# what
商品の詳細表示の設定

# why 
商品詳細表示は必須実装機能であるため

出品者（hoge)、商品の状態、配送料の負担（数字の部分）などは実装の都合上後ほどマージさせて実装させる予定です。

・編集、削除ボタンの設置（ログイン時）
[![Screenshot from Gyazo](https://gyazo.com/6c219a952c32607d990cdab9bd8faa65/raw)](https://gyazo.com/6c219a952c32607d990cdab9bd8faa65)

・購入ボタンの設置（未ログイン時）
[![Screenshot from Gyazo](https://gyazo.com/d966b4e1ec462610173d9bc59f7db467/raw)](https://gyazo.com/d966b4e1ec462610173d9bc59f7db467)