### PR TITLE
ログイン、サインアップ、詳細画面の修正

### DIFF
--- a/app/assets/stylesheets/_sign-in.scss
+++ b/app/assets/stylesheets/_sign-in.scss
@@ -71,6 +71,7 @@
             color: #fff;
             margin-top: 20px;
             border-radius: 4px;
+            border:0 ;
           }
         }
         &__forget {

--- a/app/assets/stylesheets/_user-data.scss
+++ b/app/assets/stylesheets/_user-data.scss
@@ -210,6 +210,7 @@
             color: #fff;
             margin-top: 24px;
             border-radius: 4px;
+            border: 0;
           }
           &__explanation {
             margin: 24px 0 0;

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -43,7 +43,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
   protected
 
   def delivery_info_params
-    params.require(:delivery_info).permit(:first_name, :last_name, :first_name_hurigana, :last_name_hurigana, :postal_code, :state, :city, :street, :building_name, :room_number, :phone_number)
+    params.require(:delivery_info).permit(:first_name, :last_name, :first_name_hurigana, :last_name_hurigana, :postal_code, :city, :street, :building_name, :room_number, :phone_number, :prefecture_id)
   end
   # GET /resource/edit
   # def edit

--- a/app/models/delivery_info.rb
+++ b/app/models/delivery_info.rb
@@ -1,4 +1,6 @@
 class DeliveryInfo < ApplicationRecord
+  extend ActiveHash::Associations::ActiveRecordExtensions
+  belongs_to_active_hash :prefecture
   belongs_to :user, optional: true
-  validates :first_name, :last_name, :first_name_hurigana, :last_name_hurigana, :postal_code, :state, :city, :street ,presence: true
+  validates :first_name, :last_name, :first_name_hurigana, :last_name_hurigana, :postal_code, :prefecture_id, :city, :street ,presence: true
 end

--- a/app/views/devise/registrations/new_delivery_info.html.haml
+++ b/app/views/devise/registrations/new_delivery_info.html.haml
@@ -43,7 +43,7 @@
                 都道府県
               %h2.content__title__tag
                 必須
-            = f.text_field :state, {placeholder:"例) 北海道", class:'input-text'}
+            = f.collection_select :prefecture_id, Prefecture.all, :id, :name, { include_blank: "選択してください", selected:"" }, class: "input-text"
             
             .content__title
               %h2.content__title__name

--- a/app/views/items/_form.html.haml
+++ b/app/views/items/_form.html.haml
@@ -100,9 +100,9 @@
           %h2.content__title__tag
             必須
         - if @item.persisted?
-          = form.select :status, [ ["新品、未使用",1], ["未使用に近い", 2], ["目立った傷や汚れなし", 3 ] ,["やや傷や汚れあり", 4], ["傷や汚れあり", 5], ["全体的に状態状態が悪い", 6] ], {}, class: "input-select"       
+          = form.select :status, [ ["新品、未使用","新品、未使用"], ["未使用に近い", "未使用に近い"], ["目立った傷や汚れなし", "目立った傷や汚れなし"] ,["やや傷や汚れあり", "やや傷や汚れあり"], ["傷や汚れあり", "傷や汚れあり"], ["全体的に状態状態が悪い", "全体的に状態状態が悪い"] ], {}, class: "input-select"       
         - else
-          = form.select :status, [ ["新品、未使用",1], ["未使用に近い", 2], ["目立った傷や汚れなし", 3 ] ,["やや傷や汚れあり", 4], ["傷や汚れあり", 5], ["全体的に状態状態が悪い", 6] ], { include_blank: "選択してください", selected:"" }, class: "input-select"       
+          = form.select :status, [ ["新品、未使用","新品、未使用"], ["未使用に近い", "未使用に近い"], ["目立った傷や汚れなし", "目立った傷や汚れなし"] ,["やや傷や汚れあり", "やや傷や汚れあり"], ["傷や汚れあり", "傷や汚れあり"], ["全体的に状態状態が悪い", "全体的に状態状態が悪い"] ], { include_blank: "選択してください", selected:"" }, class: "input-select"       
 
       .content
         %h1.content__info
@@ -113,9 +113,9 @@
           %h2.content__title__tag
             必須
         - if @item.persisted?
-          = form.select :postage, [ ["送料込み(出品者負担)",1], ["着払い(購入者負担)", 2]], {}, class: "input-select"
+          = form.select :postage, [ ["送料込み(出品者負担)","送料込み(出品者負担)"], ["着払い(購入者負担)", "着払い(購入者負担)"]], {}, class: "input-select"
         - else
-          = form.select :postage, [ ["送料込み(出品者負担)",1], ["着払い(購入者負担)", 2]], { include_blank: "選択してください", selected:"" }, class: "input-select"
+          = form.select :postage, [ ["送料込み(出品者負担)","送料込み(出品者負担)"], ["着払い(購入者負担)", "着払い(購入者負担)"]], { include_blank: "選択してください", selected:"" }, class: "input-select"
   
         .content__title
           %h2.content__title__name
@@ -133,9 +133,9 @@
           %h2.content__title__tag
             必須
         - if @item.persisted?
-          = form.select :shipping_days, [ ["1〜2日で発送",1], ["2〜3日で発送", 2], ["4〜7日で発送", 3]], {}, class: "input-select"    
+          = form.select :shipping_days, [ ["1〜2日で発送","1〜2日で発送"], ["2〜3日で発送", "2〜3日で発送"], ["4〜7日で発送", "4〜7日で発送"]], {}, class: "input-select"    
         - else
-          = form.select :shipping_days, [ ["1〜2日で発送",1], ["2〜3日で発送", 2], ["4〜7日で発送", 3]], { include_blank: "選択してください", selected:"" }, class: "input-select"    
+          = form.select :shipping_days, [ ["1〜2日で発送","1〜2日で発送"], ["2〜3日で発送", "2〜3日で発送"], ["4〜7日で発送", "4〜7日で発送"]], { include_blank: "選択してください", selected:"" }, class: "input-select"    
 
       .content
         %h1.content__info

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -53,7 +53,7 @@
                 = link_to '商品の編集', "/items/#{@item.id}/edit", method: :get
               %li
                 = link_to '商品の削除', "/items/#{@item.id}", method: :delete
-        -# 削除ボタン（未ログイン時に出る）
+        -# 購入ボタン（未ログイン時に出る）
         - if not user_signed_in?
           .main__show__content__item-box__logout
             %ul

--- a/db/migrate/20200602024314_remove_state_from_add_column_delivery_infos.rb
+++ b/db/migrate/20200602024314_remove_state_from_add_column_delivery_infos.rb
@@ -1,0 +1,5 @@
+class RemoveStateFromAddColumnDeliveryInfos < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :delivery_infos, :state, :string
+  end
+end

--- a/db/migrate/20200602050353_add_prefecture_id_to_add_column_delivery_infos.rb
+++ b/db/migrate/20200602050353_add_prefecture_id_to_add_column_delivery_infos.rb
@@ -1,0 +1,5 @@
+class AddPrefectureIdToAddColumnDeliveryInfos < ActiveRecord::Migration[5.2]
+  def change
+    add_column :delivery_infos, :prefecture_id, :integer, null: false
+  end
+end

--- a/db/migrate/20200602064720_remove_status_from_items.rb
+++ b/db/migrate/20200602064720_remove_status_from_items.rb
@@ -1,0 +1,5 @@
+class RemoveStatusFromItems < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :items, :status, :integer
+  end
+end

--- a/db/migrate/20200602070013_remove_postage_from_items.rb
+++ b/db/migrate/20200602070013_remove_postage_from_items.rb
@@ -1,0 +1,5 @@
+class RemovePostageFromItems < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :items, :postage, :integer
+  end
+end

--- a/db/migrate/20200602070028_remove_shipping_days_from_items.rb
+++ b/db/migrate/20200602070028_remove_shipping_days_from_items.rb
@@ -1,0 +1,5 @@
+class RemoveShippingDaysFromItems < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :items, :shipping_days, :integer
+  end
+end

--- a/db/migrate/20200602070415_add_status_to_items.rb
+++ b/db/migrate/20200602070415_add_status_to_items.rb
@@ -1,0 +1,5 @@
+class AddStatusToItems < ActiveRecord::Migration[5.2]
+  def change
+    add_column :items, :status, :string, null: false
+  end
+end

--- a/db/migrate/20200602070549_add_shipping_days_to_items.rb
+++ b/db/migrate/20200602070549_add_shipping_days_to_items.rb
@@ -1,0 +1,5 @@
+class AddShippingDaysToItems < ActiveRecord::Migration[5.2]
+  def change
+    add_column :items, :shipping_days, :string, null: false
+  end
+end

--- a/db/migrate/20200602070712_add_postage_to_items.rb
+++ b/db/migrate/20200602070712_add_postage_to_items.rb
@@ -1,0 +1,5 @@
+class AddPostageToItems < ActiveRecord::Migration[5.2]
+  def change
+    add_column :items, :postage, :string, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_28_035820) do
+ActiveRecord::Schema.define(version: 2020_06_02_070712) do
 
   create_table "categories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -29,12 +29,12 @@ ActiveRecord::Schema.define(version: 2020_05_28_035820) do
     t.string "first_name_hurigana", null: false
     t.string "last_name_hurigana", null: false
     t.integer "postal_code", null: false
-    t.string "state", null: false
     t.string "city", null: false
     t.string "street", null: false
     t.string "building_name", null: false
     t.string "room_number"
     t.integer "phone_number"
+    t.integer "prefecture_id", null: false
     t.index ["user_id"], name: "index_delivery_infos_on_user_id"
   end
 
@@ -50,14 +50,14 @@ ActiveRecord::Schema.define(version: 2020_05_28_035820) do
     t.string "name", null: false
     t.text "content", null: false
     t.string "brand"
-    t.integer "status", null: false
-    t.integer "postage", null: false
     t.integer "prefecture_id", null: false
-    t.integer "shipping_days", null: false
     t.integer "price", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "category_id"
+    t.string "status", null: false
+    t.string "shipping_days", null: false
+    t.string "postage", null: false
     t.index ["category_id"], name: "index_items_on_category_id"
   end
 


### PR DESCRIPTION
# what
ログイン、サインアップ 時のボタンのscss変更
サインアップ 時の都道府県をセレクターに変更
詳細ページのマイグレーションの削除・追加
#why
ボタンの周りのボーダーを消したいため
都道府県がセレクターでなかったため
詳細ページのカテゴリーがinteger型であったため